### PR TITLE
migrating to https api

### DIFF
--- a/lib/untappd/config.rb
+++ b/lib/untappd/config.rb
@@ -21,7 +21,7 @@ module Untappd
     attr_accessor :client_id, :client_secret, :base_uri, :gmt_offset, :redirect_url
 
     def base_uri
-      @base_uri || 'http://api.untappd.com/v4'
+      @base_uri || 'https://api.untappd.com/v4'
     end
 
   end


### PR DESCRIPTION
According to Untappd API Mailing list the http endpoint for the V4 API will stop working on Oct 1 .  https://groups.google.com/forum/#!topic/untappd-api-developer-group/LHVB_P-5EOU

I've verified that the https endpoint is already available and working
